### PR TITLE
update test and absolute path imports + new feature search dataset re…

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,0 +1,9 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+const { pathsToModuleNameMapper } = require("ts-jest");
+const {compilerOptions} = require('./tsconfig.json');
+module.exports = {
+	preset: 'ts-jest',
+	testEnvironment: 'node',
+	moduleNameMapper: pathsToModuleNameMapper(compilerOptions.paths, { prefix: '<rootDir>/' }),
+	bail: true
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,0 @@
-/** @type {import('ts-jest').JestConfigWithTsJest} */
-module.exports = {
-	preset: 'ts-jest',
-	testEnvironment: 'node',
-};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,24 +1,24 @@
 // exporting the ckan module as the default
-import CKAN from "./ckan.js";
+import CKAN from "./ckan";
 export default CKAN;
 
 // exporting response types
-export type {AutocompleteDataset} from "./parsers/autocomplete-dataset.js";
-export type {AutocompleteGroup} from "./ckan.js";
-export type {AutocompleteUser} from "./parsers/autocomplete-user.js";
-export type {Dataset} from "./parsers/dataset.js";
-export type {Group} from "./parsers/group.js";
-export type {License} from "./parsers/license.js";
-export type {Metadata, StringIndexedObject} from "./types.js";
-export type {Organization} from "./parsers/organization.js";
-export type {Resource} from "./parsers/resource.js";
-export type {Tag} from "./parsers/tag.js";
-export type {User} from "./parsers/user.js";
-export type {Vocabulary} from "./parsers/vocabulary.js";
+export type {AutocompleteDataset} from "@/parsers/autocomplete-dataset";
+export type {AutocompleteGroup} from "@/ckan";
+export type {AutocompleteUser} from "@/parsers/autocomplete-user";
+export type {Dataset} from "@/parsers/dataset";
+export type {Group} from "@/parsers/group";
+export type {License} from "@/parsers/license";
+export type {Metadata, StringIndexedObject} from "@/types";
+export type {Organization} from "@/parsers/organization";
+export type {Resource} from "@/parsers/resource";
+export type {Tag} from "@/parsers/tag";
+export type {User} from "@/parsers/user";
+export type {Vocabulary} from "@/parsers/vocabulary";
 
 // exporting options types
-export type {Settings} from "./ckan.js";
+export type {Settings} from "@/ckan";
 export type {
 	AllowedMethods, GroupOptions, LimitOptions, SortOptions, TagOptions, UserOptions,
 	SingleGroupOptions, BaseSortOptions, DatasetSearchOptions,
-} from "./types.js";
+} from "@/types";

--- a/src/parsers/dataset.ts
+++ b/src/parsers/dataset.ts
@@ -1,11 +1,11 @@
-import parseDate from "./date.js";
-import parseExtras from "./extras.js";
-import parseGroup, {Group, RawGroup} from "./group.js";
-import parseLanguages from "./languages.js";
-import parseOrganization, {Organization, RawOrganization} from "./organization.js";
-import parseResource, {Resource, RawResource} from "./resource.js";
-import parseTag, {Tag, RawTag} from "./tag.js";
-import type {StringIndexedObject, Metadata} from "../types.js";
+import parseDate from "@/parsers/date";
+import parseExtras from "@/parsers/extras";
+import parseGroup, {Group, RawGroup} from "@/parsers/group";
+import parseLanguages from "@/parsers/languages";
+import parseOrganization, {Organization, RawOrganization} from "@/parsers/organization";
+import parseResource, {Resource, RawResource} from "@/parsers/resource";
+import parseTag, {Tag, RawTag} from "@/parsers/tag";
+import type {StringIndexedObject, Metadata} from "@/types";
 
 /** Processed CKAN dataset type */
 export interface Dataset{

--- a/src/parsers/extras.ts
+++ b/src/parsers/extras.ts
@@ -1,4 +1,4 @@
-import type {StringIndexedObject} from "../types.js";
+import type {StringIndexedObject} from "@/types";
 
 /** Raw extras type */
 export interface RawExtra{

--- a/src/parsers/group.ts
+++ b/src/parsers/group.ts
@@ -1,7 +1,7 @@
-import parseDate from "./date.js";
-import parseExtras from "./extras.js";
-import parseUser, {User, RawUser} from "./user.js";
-import type {StringIndexedObject} from "../types.js";
+import parseDate from "@/parsers/date";
+import parseExtras from "@/parsers/extras";
+import parseUser, {User, RawUser} from "@/parsers/user";
+import type {StringIndexedObject} from "@/types";
 
 
 /** Group type */

--- a/src/parsers/license.ts
+++ b/src/parsers/license.ts
@@ -1,4 +1,4 @@
-import type {StringIndexedObject} from "../types.js";
+import type {StringIndexedObject} from "@/types";
 
 /** License type */
 export interface License{

--- a/src/parsers/organization.ts
+++ b/src/parsers/organization.ts
@@ -1,7 +1,7 @@
-import parseDate from "./date.js";
-import parseExtras from "./extras.js";
-import parseUser, {User, RawUser} from "./user.js";
-import type {StringIndexedObject} from "../types.js";
+import parseDate from "@/parsers/date";
+import parseExtras from "@/parsers/extras";
+import parseUser, {User, RawUser} from "@/parsers/user";
+import type {StringIndexedObject} from "@/types";
 
 /** Organization CKAN type */
 export interface Organization{
@@ -64,30 +64,34 @@ export interface RawOrganization{
  * @param {RawOrganization} [organization]
  * @returns {Organization}
  */
-export default function parseOrganization(organization: RawOrganization): Organization{
-	const {
-		approval_status, created, dataset_count, description, display_name, extras, id, image_display_url, image_url,
-		is_organization, name, num_followers, package_count, state, title, type, users,
-		...rest
-	} = organization;
-	return {
-		approvalStatus: approval_status,
-		created: parseDate(created),
-		description: description ?? "",
-		displayName: display_name,
-		id,
-		imageUrl: image_display_url ?? image_url,
-		isOrganization: is_organization ?? true,
-		name: name ?? "",
-		state,
-		stats: {
-			// the vocabulary across the api is inconsistent
-			datasets: dataset_count ?? package_count,
-			followers: num_followers,
-		},
-		title: title ?? "",
-		type,
-		users: users ? users.map(x => parseUser(x)) : [],
-		additionalData: {...rest, ...parseExtras(extras)}
-	};
+export default function parseOrganization(organization?: RawOrganization): Organization{
+	if (organization) {
+		const {
+			approval_status, created, dataset_count, description, display_name, extras, id, image_display_url, image_url,
+			is_organization, name, num_followers, package_count, state, title, type, users,
+			...rest
+		} = organization;
+		return {
+			approvalStatus: approval_status,
+			created: parseDate(created),
+			description: description ?? "",
+			displayName: display_name,
+			id,
+			imageUrl: image_display_url ?? image_url,
+			isOrganization: is_organization ?? true,
+			name: name ?? "",
+			state,
+			stats: {
+				// the vocabulary across the api is inconsistent
+				datasets: dataset_count ?? package_count,
+				followers: num_followers,
+			},
+			title: title ?? "",
+			type,
+			users: users ? users.map(x => parseUser(x)) : [],
+			additionalData: {...rest, ...parseExtras(extras)}
+		};
+	} else {
+		return undefined;
+	}
 }

--- a/src/parsers/resource.ts
+++ b/src/parsers/resource.ts
@@ -1,6 +1,6 @@
-import parseDate from "./date.js";
-import parseLanguages from "./languages.js";
-import type {StringIndexedObject, Metadata} from "../types.js";
+import parseDate from "@/parsers/date";
+import parseLanguages from "@/parsers/languages";
+import type {StringIndexedObject, Metadata} from "@/types";
 
 /** Processed resource type */
 export interface Resource{

--- a/src/parsers/tag.ts
+++ b/src/parsers/tag.ts
@@ -1,4 +1,4 @@
-import type {StringIndexedObject} from "../types.js";
+import type {StringIndexedObject} from "@/types";
 
 /** Tag type */
 export interface Tag{

--- a/src/parsers/user.ts
+++ b/src/parsers/user.ts
@@ -1,6 +1,6 @@
-import parseDate from "./date.js";
+import parseDate from "@/parsers/date";
 
-import type {StringIndexedObject} from "../types.js";
+import type {StringIndexedObject} from "@/types";
 
 /** User type */
 export interface User{

--- a/src/parsers/vocabulary.ts
+++ b/src/parsers/vocabulary.ts
@@ -1,5 +1,5 @@
-import parseTag, {Tag, RawTag} from "./tag.js";
-import type {StringIndexedObject} from "../types.js";
+import parseTag, {Tag, RawTag} from "@/parsers/tag";
+import type {StringIndexedObject} from "@/types";
 
 /** Vocabulary type */
 export interface Vocabulary{

--- a/tests/ckan.test.ts
+++ b/tests/ckan.test.ts
@@ -47,16 +47,16 @@ describe("autocomplete endpoints", () => {
 		const results = await parser.autocompleteDataset("sample");
 		expect(results).toEqual([{
 			name: "sample-dataset-1",
-			title: "Sample Dataset",
+			title: "Sample dataset 1",
 			match: {field: "name", displayed: "sample-dataset-1"}
 		}]);
 	});
 	test("autocomplete group", async () => {
-		const results = await parser.autocompleteGroup("my");
+		const results = await parser.autocompleteGroup("da");
 		expect(results).toEqual([{
-			id: "866b1d34-6414-4f6e-bcda-85e00c44fe42",
-			name: "my-group",
-			title: "My Group"
+			id: "ded220b4-c665-4312-95d0-8c3ec969441f",
+			name: "david",
+			title: "Dave's books"
 		}]);
 	});
 	test("autocomplete format", async () => {
@@ -66,15 +66,15 @@ describe("autocomplete endpoints", () => {
 		expect(await parser.autocompleteFormat("geo")).toEqual(["geojson"]);
 	});
 	test("autocomplete organization", async () => {
-		expect(await parser.autocompleteOrganization("sample")).toEqual([{
-			id: "1fa89238-ee96-4439-a885-22d15244d070",
-			name: "sample-organization",
-			title: "Sample Organization"
+		expect(await parserItaly.autocompleteOrganization("isp")).toEqual([{
+			id: "ac8db934-572c-4e68-b00c-2fc3d8a29050",
+			name: "ispra",
+			title: "ISPRA"
 		}]);
-	});
+	}, 10000);
 	test("autocomplete user", async() => {
 		const results = await parserItaly.autocompleteUser("admin");
-		expect(results[0]).toMatchObject({id: "b549687d-3768-4e8a-b3a9-f0f94d0b96d9", name: "ckanadmin"});
+		expect(results[0]).toMatchObject({id: "ab485f90-2f37-4a9b-8fb6-5296cf486d33", name: "ckan_admin"});
 	});
 });
 
@@ -82,25 +82,29 @@ describe("dataset-related endpoints", () => {
 	test("basic package lists", async () => {
 		const results = await parser.datasets();
 		expect(results.every(x => typeof x === "string")).toBe(true);
-		expect(results).toEqual(["sample-dataset-1"]);
+		expect(results).toEqual([
+			'annakarenina',
+			'sample-dataset-1',
+			'warandpeace'
+		]);
 	});
 	test("detailed package lists", async () => {
 		const results = await parser.detailedDatasets();
 		expect(results.some(x => typeof x === "string")).toBe(false);
-		expect(results.length).toBe(1);
+		expect(results.length).toBe(3);
 		expect(results[0]).toMatchObject({
 			author: {
-				name: "Test Author",
-				email: "test@email.com"
+				name: "",
+				email: ""
 			},
 			license: {
-				id: "cc-by",
-				title: "Creative Commons Attribution",
-				url: "http://www.opendefinition.org/licenses/cc-by"
+				id: "ODC-PDDL-1.0",
+				title: "Open Data Commons Public Domain Dedication and Licence 1.0",
+				url: "http://www.opendefinition.org/licenses/odc-pddl"
 			},
 			metadata: {
-				created: new Date("2021-04-09T11:39:37.657233"),
-				modified: new Date("2022-05-20T09:20:43.998956")
+				created: new Date("2024-02-27T14:15:54.573058"),
+				modified: new Date("2024-05-16T07:58:26.405378")
 			},
 			name: "sample-dataset-1"
 		});
@@ -111,7 +115,7 @@ describe("group-related endpoints", () => {
 	test("can basic groups", async () => {
 		const results = await parser.groups();
 		expect(results.every(x => typeof x === "string")).toBe(true);
-		expect(results).toEqual(["my-group", "test-group"]);
+		expect(results).toEqual(["david", "roger"]);
 	});
 	test("can get detailed groups without additional information", async () => {
 		const results = await parser.detailedGroups();
@@ -154,9 +158,9 @@ describe("meta-api endpoints", () => {
 
 describe("organization-related endpoints", () => {
 	test("basic organization lists", async () => {
-		const results = await parser.organizations();
+		const results = await parserItaly.organizations();
 		expect(results.every(x => typeof x === "string")).toBe(true);
-		expect(results).toEqual(["city-of-london", "sample-organization", "test_organization"]);
+		expect(results).toContain("agenzia-per-l-italia-digitale");
 	});
 	test("full organization lists", async () => {
 		const results = await parser.detailedOrganizations();
@@ -165,8 +169,8 @@ describe("organization-related endpoints", () => {
 		// once again, the correct handling of such data is therefore left to the parser tests
 	});
 	test("single organization", async() => {
-		const results = await parser.organization("sample-organization");
-		expect(results.title).toBe("Sample Organization");
+		const results = await parserItaly.organization("ispra");
+		expect(results.title).toBe("ISPRA");
 	});
 });
 
@@ -174,7 +178,11 @@ describe("tag-related endpoints", () => {
 	test("basic tag lists", async () => {
 		const results = await parser.tags();
 		expect(results.every(x => typeof x === "string")).toBe(true);
-		expect(results).toEqual(["csv", "economy", "geojson", "kml", "pdf", "sample", "txt", "wms"]);
+		expect(results).toEqual([
+			'Flexible ァ',
+			'russian',
+			'tolstoy'
+		]);
 	});
 	test("detailed tag lists", async () => {
 		const results = await parser.detailedTags();
@@ -196,8 +204,8 @@ describe("vocabulary-related endpoints", () => {
 		expect(results.some(x => typeof x === "string")).toBe(false);
 	});
 	test("can get vocabulary", async () => {
-		const results = await parserItaly.vocabulary("ae537949-d633-46c0-b41b-c9580aacd178");
-		expect(results.id).toBe("ae537949-d633-46c0-b41b-c9580aacd178");
+		const results = await parserItaly.vocabulary("a1908578-5f0b-451c-8b80-9e98f95feb25");
+		expect(results.id).toBe("a1908578-5f0b-451c-8b80-9e98f95feb25");
 		expect(results.name).toBe("languages");
 		const tags = results.tags.map(x => x.name);
 		expect(tags.includes("ITA")).toBe(true);
@@ -208,5 +216,22 @@ describe("malformed responses", () => {
 	// the italian endpoint has a faulty implementation for all_fields=false, meaning that it will never be an array of strings
 	test("errors on malformed response", () => {
 		expect(parserItaly.users()).rejects.toThrow();
+	}, 20000);
+});
+
+describe("search-related endpoints", () => {
+	test("can search datasets with query", async () => {
+		const results = await parser.searchDataset("sample");
+		expect(results.length).toBe(1);
+		expect(results[0].name).toBe("sample-dataset-1");
+	}, 20000);
+	test("can search datasets with filterQuery", async () => {
+		const results = await parser.searchDataset("", {filterQuery: ["groups:david", "tags:tolstoy"]});
+		expect(results.length).toBe(1);
+		expect(results[0].name).toBe("annakarenina");
+	}, 20000);
+	test("can search using the raw result response", async () => {
+		const response = await parser.searchDatasetRawResult("sample");
+		expect(response.count).toBe(1);
 	}, 20000);
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,17 +4,16 @@
     	"forceConsistentCasingInFileNames": true,
     	"noEmit": false,
     	"incremental": true,
-    	"module": "esnext",
-        "moduleResolution": "nodenext",
+        "module": "ES2022",
+        "moduleResolution": "Bundler",
         "allowSyntheticDefaultImports": true,
     	"isolatedModules": true,
     	"target": "esnext",
     	"rootDir": "src",
         "outDir": "dist",
         "declaration": true,
-        "baseUrl": "./src",
         "paths": {
-            "parsers/*": ["parsers/*"],
+            "@/*": ["./src/*"]
         }
 	},
     "exclude": [


### PR DESCRIPTION
Changelog:
- use absolute imports for ts files within app (using notation @)
- update tests to match the new CKAN endpoint results (only one test failing)
- add new feature: `searchDatasetRawResults` to get the raw CKAN result JSON including things like `facets` and `count` 